### PR TITLE
Add campus-aware offline page with Palomar support

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,5 +1,19 @@
 <!doctype html>
 <html lang="en">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="theme-color" content="#f8ad9d"><title>UMS is offline</title><link rel="stylesheet" href="/assets/css/launch.css?v=20260813-ums-menu-v13"></head>
-<body><main class="container section-space"><div class="policy-card"><span class="eyebrow">Offline</span><h1>You’re not connected just now.</h1><p>The UMS launch page needs a connection to open signup or join a waitlist. Check your connection and try again.</p><a class="btn btn-ums" href="/ucd/">Return to the UCD page</a></div></main></body>
+<body><main class="container section-space"><div class="policy-card"><span class="eyebrow">Offline</span><h1>You’re not connected just now.</h1><p>The UMS launch page needs a connection to open signup or join a waitlist. Check your connection and try again.</p><a class="btn btn-ums" id="offline-return" href="/">Return to the UMS page</a></div></main>
+<script>
+(function () {
+  var link = document.getElementById('offline-return');
+  var path = window.location.pathname;
+  if (path.indexOf('/palomar') === 0) {
+    link.href = '/palomar/';
+    link.textContent = 'Return to the Palomar page';
+  } else if (path.indexOf('/ucd') === 0) {
+    link.href = '/ucd/';
+    link.textContent = 'Return to the UCD page';
+  }
+})();
+</script>
+</body>
 </html>

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -11,9 +11,10 @@ fi
 
 mkdir -p "${output_dir}"
 find "${output_dir}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
-mkdir -p "${output_dir}/assets" "${output_dir}/ucd" "${output_dir}/privacy-policy" "${output_dir}/terms"
+mkdir -p "${output_dir}/assets" "${output_dir}/ucd" "${output_dir}/palomar" "${output_dir}/privacy-policy" "${output_dir}/terms"
 cp "${project_dir}/index.html" "${project_dir}/manifest.json" "${project_dir}/sitemap.xml" "${project_dir}/offline.html" "${project_dir}/sw.js" "${output_dir}/"
 cp "${project_dir}/ucd/index.html" "${output_dir}/ucd/index.html"
+cp "${project_dir}/palomar/index.html" "${output_dir}/palomar/index.html"
 cp "${project_dir}/privacy-policy/index.html" "${output_dir}/privacy-policy/index.html"
 cp "${project_dir}/terms/index.html" "${output_dir}/terms/index.html"
 cp -R "${project_dir}/assets/." "${output_dir}/assets/"

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ums-landing-v35-campus-brand-alignment';
+const CACHE_NAME = 'ums-landing-v36-campus-aware-offline';
 const APP_SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
This PR enhances the offline page to be context-aware, dynamically returning users to the correct campus page based on their current location. It also adds support for the Palomar campus alongside the existing UCD campus.

## Key Changes
- **offline.html**: Added dynamic script that detects the current path and updates the return link and text accordingly
  - Returns to `/palomar/` for Palomar campus users
  - Returns to `/ucd/` for UCD campus users
  - Defaults to `/` for other paths
- **scripts/build-static.sh**: Updated build script to include Palomar directory in the static output
- **sw.js**: Updated service worker cache version to reflect the new campus-aware offline functionality

## Implementation Details
The offline page now uses a self-executing function to inspect `window.location.pathname` and conditionally set the return link's `href` and `textContent`. This ensures users are directed back to their respective campus page when they regain connectivity, improving the user experience across multiple campus deployments.

https://claude.ai/code/session_017aLBYi8wnLgNXjHgH2vCbo